### PR TITLE
Adding Collapsibility to ExpandableText

### DIFF
--- a/Example/ExpandableTextExample/ContentView.swift
+++ b/Example/ExpandableTextExample/ContentView.swift
@@ -31,6 +31,7 @@ struct ContentView: View {
                     .moreButtonColor(.red)
                     .expandAnimation(.easeInOut(duration: 2))
                     .trimMultipleNewlinesWhenTruncated(false)
+                    .enableCollapse(true)
                     .border(.red)
                 
                 ExpandableText("**Markdown** is _supported_")

--- a/Sources/ExpandableText/ExpandableText+Modifiers.swift
+++ b/Sources/ExpandableText/ExpandableText+Modifiers.swift
@@ -88,6 +88,17 @@ public extension ExpandableText {
     }
     
     /**
+      Enables collapsing behavior by tapping on the text body when the state is expanded.
+      - Parameter value: Whether or not to enable collapse functionality.
+      - Returns: A new `ExpandableText` instance with the specified collapse ability applied.
+      */
+     func enableCollapse(_ value: Bool) -> Self {
+         var copy = self
+         copy.collapseEnabled = value
+         return copy
+     }
+    
+    /**
      Sets whether multiple consecutive newline characters should be trimmed when truncating the text in the `ExpandableText` instance.
      - Parameter value: A boolean value indicating whether to trim multiple consecutive newline characters. Defaults to `true`
      - Returns: A new `ExpandableText` instance with the specified trimming behavior applied.

--- a/Sources/ExpandableText/ExpandableText.swift
+++ b/Sources/ExpandableText/ExpandableText.swift
@@ -42,6 +42,7 @@ public struct ExpandableText: View {
     internal var moreButtonFont: Font?
     internal var moreButtonColor: Color = .accentColor
     internal var expandAnimation: Animation = .default
+    internal var collapseEnabled: Bool = false
     internal var trimMultipleNewlinesWhenTruncated: Bool = true
     
     /**
@@ -79,7 +80,8 @@ public struct ExpandableText: View {
             )
             .contentShape(Rectangle())
             .onTapGesture {
-                if shouldShowMoreButton {
+                if (isExpanded && collapseEnabled) ||
+                     shouldShowMoreButton {
                     withAnimation(expandAnimation) { isExpanded.toggle() }
                 }
             }


### PR DESCRIPTION
Adding ability and switch for `ExpandableView` to be collapsed by tapping on expanded text body.