### PR TITLE
Add option to set more button pressed color

### DIFF
--- a/Sources/ExpandableText/ExpandableText+Modifiers.swift
+++ b/Sources/ExpandableText/ExpandableText+Modifiers.swift
@@ -77,6 +77,17 @@ public extension ExpandableText {
     }
     
     /**
+     Sets the pressed color to use for the "show more" button in the `ExpandableText` instance.
+     - Parameter color: The color to use for the "show more" button pressed state.
+     - Returns: A new `ExpandableText` instance with the specified "show more" button pressed color applied.
+     */
+    func moreButtonPressedColor(_ color: Color) -> Self {
+        var copy = self
+        copy.moreButtonPressedColor = color
+        return copy
+    }
+
+    /**
      Sets the animation to use when expanding the `ExpandableText` instance.
      - Parameter animation: The animation to use for the expansion. Defaults to `default`
      - Returns: A new `ExpandableText` instance with the specified expansion animation applied.

--- a/Sources/ExpandableText/ExpandableText.swift
+++ b/Sources/ExpandableText/ExpandableText.swift
@@ -86,19 +86,17 @@ public struct ExpandableText: View {
                     withAnimation(expandAnimation) { isExpanded.toggle() }
                 }
             }
-            .modifier(OverlayAdapter(alignment: .trailingLastTextBaseline, view: {
-                if shouldShowMoreButton {
-                    if let moreButtonPressedColor {
-                        button
-                            .buttonStyle(
-                                .pressedColorButton(moreButtonColor, moreButtonPressedColor)
-                            )
-                    } else {
-                        button
-                            .foregroundColor(moreButtonColor)
-                    }
+            .modifier(OverlayAdapter(alignment: .trailingLastTextBaseline) {
+                if let moreButtonPressedColor {
+                    button
+                        .buttonStyle(
+                            .pressedColorButton(moreButtonColor, moreButtonPressedColor)
+                        )
+                } else {
+                    button
+                        .foregroundColor(moreButtonColor)
                 }
-            }))
+            })
     }
     
     private var content: some View {
@@ -119,6 +117,7 @@ public struct ExpandableText: View {
             Text(moreButtonText)
                 .font(moreButtonFont ?? font)
         }
+        .opacity(shouldShowMoreButton ? 1 : 0)
     }
 
     private var shouldShowMoreButton: Bool {

--- a/Sources/ExpandableText/ExpandableText.swift
+++ b/Sources/ExpandableText/ExpandableText.swift
@@ -41,6 +41,7 @@ public struct ExpandableText: View {
     internal var moreButtonText: String = "more"
     internal var moreButtonFont: Font?
     internal var moreButtonColor: Color = .accentColor
+    internal var moreButtonPressedColor: Color?
     internal var expandAnimation: Animation = .default
     internal var collapseEnabled: Bool = false
     internal var trimMultipleNewlinesWhenTruncated: Bool = true
@@ -87,11 +88,13 @@ public struct ExpandableText: View {
             }
             .modifier(OverlayAdapter(alignment: .trailingLastTextBaseline, view: {
                 if shouldShowMoreButton {
-                    Button {
-                        withAnimation(expandAnimation) { isExpanded.toggle() }
-                    } label: {
-                        Text(moreButtonText)
-                            .font(moreButtonFont ?? font)
+                    if let moreButtonPressedColor {
+                        button
+                            .buttonStyle(
+                                .pressedColorButton(moreButtonColor, moreButtonPressedColor)
+                            )
+                    } else {
+                        button
                             .foregroundColor(moreButtonColor)
                     }
                 }
@@ -109,11 +112,42 @@ public struct ExpandableText: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
+    private var button: some View {
+        Button {
+            withAnimation(expandAnimation) { isExpanded.toggle() }
+        } label: {
+            Text(moreButtonText)
+                .font(moreButtonFont ?? font)
+        }
+    }
+
     private var shouldShowMoreButton: Bool {
         !isExpanded && isTruncated
     }
     
     private var textTrimmingDoubleNewlines: String {
         text.replacingOccurrences(of: #"\n\s*\n"#, with: "\n", options: .regularExpression)
+    }
+}
+
+internal struct PressedColorButton: ButtonStyle {
+    let moreButtonColor: Color
+    let moreButtonPressedColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(configuration.isPressed ? moreButtonPressedColor : moreButtonColor)
+    }
+}
+
+internal extension ButtonStyle where Self == PressedColorButton {
+    static func pressedColorButton(
+        _ moreButtonColor: Color,
+        _ moreButtonPressedColor: Color
+    ) -> Self {
+        Self(
+            moreButtonColor: moreButtonColor,
+            moreButtonPressedColor: moreButtonPressedColor
+        )
     }
 }

--- a/Sources/Utilities/TruncationTextMask.swift
+++ b/Sources/Utilities/TruncationTextMask.swift
@@ -40,6 +40,7 @@ private struct TruncationTextMask: ViewModifier {
                         }.frame(height: size.height)
                     }
                 )
+                .fixedSize(horizontal: false, vertical: true)
         } else {
             content
                 .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Needed to customize the pressed color on more button to match app's existing UI.

Also fixed an intrinsic size issue when using UIHostingController in UIKit.

Added second fix to use opacity modifier to show/hide more button. The previous branch logic isn't "SwiftUI-y" and has an "undesirable" animation side effect.